### PR TITLE
fix: fix for obsidian v0.15.6. focus on editor after revealing file.

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -20,9 +20,12 @@ export default class MyPlugin extends Plugin {
 		return is_open;
 
 	}
-	private reveal()
+	private async reveal()
 	{
 		(this.app as any).commands.executeCommandById('file-explorer:reveal-active-file');
+		await new Promise(resolve => setTimeout(resolve, 100));
+		(this.app as any).commands.executeCommandById('editor:focus');
+
 	}
 
 	onload() {


### PR DESCRIPTION
In the past, after revealing a file, the editor still has focus.
But since obsidian v0.15.6, the editor loses focus.

The PR fix this bug.