### PR TITLE
fixes inability to focus new tab when plugin enabled (closes #27)

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -32,7 +32,7 @@ export default class MyPlugin extends Plugin {
 	private is_file(leaf: WorkspaceLeaf) 
 	{
 		// This code does not verify whether it represents all files.
-		return (leaf.view as FileView).allowNoFile === false;
+		return (leaf.view as FileView).allowNoFile === true;
 	}
 
 	private is_file_explorer(leaf: WorkspaceLeaf) 


### PR DESCRIPTION
If I'm understanding correctly, the [`is_file()` function](https://github.com/shichongrui/obsidian-reveal-active-file/blob/052b1700252e126af47d8e8cca92ed7ae41cbebe/main.ts#L32C1-L36C3) should have the logical eval flipped, such that it allows for the case where the currently focused tab (`leaf`) is not a file, which I interpret to mean "a saved file in the obsidian vault."

This doesn't change that it's strange for this condition to prevent viewing the tab, though, since that seems a little backwards to me 🤷‍♂️

Cheers

_edit:_ I'll also note that it appears to have fixed the issue for me, but I have not tested it rigorously.