### PR TITLE
Hide the log unless enable Verbose in Developer Tools

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -62,7 +62,7 @@ export default class MyPlugin extends Plugin {
 
 			this.resolve_wait_active_leaf_change()
 			const is_file_explorer_open_now = this.is_file_explorer_open();
-			console.log(`is_file_explorer_open_previously: ${this.is_file_explorer_open_previously}, is_file_explorer_open_now: ${is_file_explorer_open_now}`);
+			console.debug(`is_file_explorer_open_previously: ${this.is_file_explorer_open_previously}, is_file_explorer_open_now: ${is_file_explorer_open_now}`);
 			if(this.is_file_explorer(leaf))
 			{
 				if(is_file_explorer_open_now && ! this.is_file_explorer_open_previously)


### PR DESCRIPTION
Hide the log unless enable Verbose in Developer Tools (disable by default), Verbose < Info ＜ Warnings ＜ Errors


<img width="1092" alt="image" src="https://github.com/user-attachments/assets/7a6852d3-0a70-4790-875a-9cb281b5791f" />

Self Test Report:
1. When disable the Verbose level. No log appears.
2. When enabling the Verbose level. I can see previous and future logs.